### PR TITLE
bug fix issues1: throw UnexpectedException know to client so that the…

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
+        <option name="testRunner" value="GRADLE" />
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
         <option name="modules">
@@ -11,7 +13,6 @@
             <option value="$PROJECT_DIR$/GenesisAndroid" />
           </set>
         </option>
-        <option name="resolveModulePerSourceSet" value="false" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,25 +1,39 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="NullableNotNullManager">
     <option name="myDefaultNullable" value="android.support.annotation.Nullable" />
     <option name="myDefaultNotNull" value="android.support.annotation.NonNull" />
     <option name="myNullables">
       <value>
-        <list size="4">
+        <list size="12">
           <item index="0" class="java.lang.String" itemvalue="org.jetbrains.annotations.Nullable" />
           <item index="1" class="java.lang.String" itemvalue="javax.annotation.Nullable" />
           <item index="2" class="java.lang.String" itemvalue="edu.umd.cs.findbugs.annotations.Nullable" />
           <item index="3" class="java.lang.String" itemvalue="android.support.annotation.Nullable" />
+          <item index="4" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NullableDecl" />
+          <item index="5" class="java.lang.String" itemvalue="androidx.annotation.Nullable" />
+          <item index="6" class="java.lang.String" itemvalue="org.eclipse.jdt.annotation.Nullable" />
+          <item index="7" class="java.lang.String" itemvalue="com.android.annotations.Nullable" />
+          <item index="8" class="java.lang.String" itemvalue="androidx.annotation.RecentlyNullable" />
+          <item index="9" class="java.lang.String" itemvalue="javax.annotation.CheckForNull" />
+          <item index="10" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.qual.Nullable" />
+          <item index="11" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NullableType" />
         </list>
       </value>
     </option>
     <option name="myNotNulls">
       <value>
-        <list size="4">
+        <list size="11">
           <item index="0" class="java.lang.String" itemvalue="org.jetbrains.annotations.NotNull" />
           <item index="1" class="java.lang.String" itemvalue="javax.annotation.Nonnull" />
           <item index="2" class="java.lang.String" itemvalue="edu.umd.cs.findbugs.annotations.NonNull" />
           <item index="3" class="java.lang.String" itemvalue="android.support.annotation.NonNull" />
+          <item index="4" class="java.lang.String" itemvalue="androidx.annotation.RecentlyNonNull" />
+          <item index="5" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.qual.NonNull" />
+          <item index="6" class="java.lang.String" itemvalue="com.android.annotations.NonNull" />
+          <item index="7" class="java.lang.String" itemvalue="androidx.annotation.NonNull" />
+          <item index="8" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NonNullType" />
+          <item index="9" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NonNullDecl" />
+          <item index="10" class="java.lang.String" itemvalue="org.eclipse.jdt.annotation.NonNull" />
         </list>
       </value>
     </option>
@@ -58,7 +72,7 @@
       </profile-state>
     </entry>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="zulu-1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -4,6 +4,11 @@
     <modules>
       <module fileurl="file://$PROJECT_DIR$/GenesisAndroid/GenesisAndroid.iml" filepath="$PROJECT_DIR$/GenesisAndroid/GenesisAndroid.iml" />
       <module fileurl="file://$PROJECT_DIR$/android_sdk.iml" filepath="$PROJECT_DIR$/android_sdk.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/GenesisAndroid/android_sdk.GenesisAndroid.iml" filepath="$PROJECT_DIR$/.idea/modules/GenesisAndroid/android_sdk.GenesisAndroid.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/GenesisAndroid/android_sdk.GenesisAndroid.androidTest.iml" filepath="$PROJECT_DIR$/.idea/modules/GenesisAndroid/android_sdk.GenesisAndroid.androidTest.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/GenesisAndroid/android_sdk.GenesisAndroid.main.iml" filepath="$PROJECT_DIR$/.idea/modules/GenesisAndroid/android_sdk.GenesisAndroid.main.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/GenesisAndroid/android_sdk.GenesisAndroid.unitTest.iml" filepath="$PROJECT_DIR$/.idea/modules/GenesisAndroid/android_sdk.GenesisAndroid.unitTest.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/githhub_android.android_sdk.iml" filepath="$PROJECT_DIR$/.idea/modules/githhub_android.android_sdk.iml" />
     </modules>
   </component>
 </project>

--- a/GenesisAndroid/src/main/java/com/emerchantpay/gateway/genesisandroid/api/network/HttpAsyncTask.kt
+++ b/GenesisAndroid/src/main/java/com/emerchantpay/gateway/genesisandroid/api/network/HttpAsyncTask.kt
@@ -111,6 +111,7 @@ class HttpAsyncTask(private val configuration: Configuration?) : AsyncTask<Any, 
             } catch (unexpectedException: UnexpectedException) {
                 // TODO Auto-generated catch block
                 Log.e("Unexpected Exception", unexpectedException.toString())
+                throw UnexpectedException(e.message, e)
             }
 
         } finally {


### PR DESCRIPTION
Fix bug when exception also returns to the client.

https://github.com/GenesisGateway/android_sdk/issues/1

Return to client Exception by throwing UnexpectedException(e.message, e) so that the client can know the exception

try {
                throw UnexpectedException(e.message, e)
            } catch (unexpectedException: UnexpectedException) {
                // TODO Auto-generated catch block
                Log.e("Unexpected Exception", unexpectedException.toString())
                throw UnexpectedException(e.message, e)
            }
